### PR TITLE
Allow each dashboard define its own custom routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,47 @@ $ go run examples/sample/sample.go
 
 You will need two directories from the Dashing repo: `www` and `javascripts`. We also ship the directories with this repo.
 
+### Define Custom Routes
+
+```go
+package main
+
+import (
+	"log"
+
+	dashing "github.com/znly/go-dashing"
+	"github.com/znly/go-dashing/jobs/buzzwords"
+	"github.com/znly/go-dashing/jobs/convergence"
+	"github.com/znly/go-dashing/jobs/sample"
+	"github.com/gin-gonic/gin"
+)
+
+func sayHiHandler(c *gin.Context) {
+	c.JSON(200, gin.H{"message": "hi there!"})
+}
+
+func main() {
+	// Create a new Dashing server running the sample dashboard
+	dashingDashboards, err := dashing.NewDashing("www/", "javascripts/", "sample", "auth-dev", "127.0.0.1", "5005", false)
+	if err != nil {
+		log.Fatalf("Err: %s", err)
+	}
+
+	//Define custom routes
+	routes := []*dashing.CustomRoute{
+		&dashing.CustomRoute{"/say-hi", "GET",sayHiHandler},
+	}
+	dashingDashboards.ConfigureCustomRoutes(routes)
+
+	// Register default sample jobs
+	dashingDashboards.Register(sample.GetJob(), convergence.GetJob(), buzzwords.GetJob())
+
+	// Start the server
+	log.Fatal(dashingDashboards.Start())
+}
+
+```
+
 ##  WARNING
 
 Go-Dashing is using some native libraries (such as `libsass` and `duktape`), and thus may take some time to compile. Use ```go install``` to avoid recompiling them too often.

--- a/dashing.go
+++ b/dashing.go
@@ -28,6 +28,10 @@ func (d *Dashing) Register(jobs ...Job) {
 	d.worker.register(jobs...)
 }
 
+func (d *Dashing) ConfigureCustomRoutes(routes []*CustomRoute){
+	d.server.ConfigureCustomRoutes(routes)
+}
+
 // NewDashing sets up the event broker, workers and webservice.
 func NewDashing(webroot, dashingJSRoot, defaultDashboard, authToken, host, port string, dev bool) (*Dashing, error) {
 	broker := newBroker()


### PR DESCRIPTION
- Exposing a function to register new custom routes
- Registering custom routes only after default routes are registered
- Update Readme showing how to use it.

Whit this change, each dashboard can define its own custom routes when needed.